### PR TITLE
Feature/global state setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,8 @@
         "stompjs": "^2.3.3",
         "styled-components": "^6.1.13",
         "tailwind-merge": "^2.5.5",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
@@ -17188,6 +17189,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "stompjs": "^2.3.3",
     "styled-components": "^6.1.13",
     "tailwind-merge": "^2.5.5",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Signin from './Pages/Signin';
 import Signup from './Pages/Signup';
 import Dashboard from './Pages/Dashboard';
 import { WebSocketProvider } from './Context/WebSocketContext';
+import { GlobalProvider } from './States/UseStore';
 import { useState} from 'react';
 
 function App() {
@@ -15,6 +16,7 @@ function App() {
   return (
     <>
     <WebSocketProvider isLoggedIn={isLoggedIn}>
+    <GlobalProvider>
       <Router>
         <Routes>
           <Route path='/' element={<Signin onLogin={handleLogin} />} />
@@ -22,6 +24,7 @@ function App() {
           <Route path='/Dashboard' element={<Dashboard/>} />
         </Routes>
       </Router>
+      </GlobalProvider>
     </WebSocketProvider>
     </>
   )

--- a/src/Components/Chats.jsx
+++ b/src/Components/Chats.jsx
@@ -17,7 +17,7 @@ export default function Chats({showDirectMessages, darkMode, setReceiverId, setS
     const [favouriteChats, setFavouriteChats] = useState([]);
     const [acceptedProfiles, setAcceptedProfiles] = useState([]);
     const [isFetched, setIsFetched] = useState(false);
-    const [loading, setLoading] = useState(true);
+    const [loading, setLoading] = useState(false);
     const [loading2, setLoading2] = useState(true);
     const [loading3, setLoading3] = useState(true);
     const [showAll, setShowAll] = useState(true);
@@ -31,6 +31,8 @@ export default function Chats({showDirectMessages, darkMode, setReceiverId, setS
 
     const getSearchResults = async (value) => {
         try {
+            setLoading(true);
+            setChats([]); 
             const friendIds = await searchChats(value); 
             const chatPreviews = await Promise.all(
                 friendIds.map(async (friendId) => {
@@ -182,7 +184,7 @@ export default function Chats({showDirectMessages, darkMode, setReceiverId, setS
                         </>
                         )}
                     {showAll ? (
-                        loadingDirectChats && isFetched ? (
+                        loadingDirectChats || loading ? (
                             <div>
                             {[...Array(6)].map((_, index) => (
                               <div key={index} className="space-y-2">
@@ -198,7 +200,7 @@ export default function Chats({showDirectMessages, darkMode, setReceiverId, setS
                             ))}
                           </div>
                         ) : (
-                            directChats
+                            (searchKeyword === '' ? directChats : chats)
                                 .sort((a, b) => new Date(b.lastActiveTime) - new Date(a.lastActiveTime))
                                 .map((chat) => {
                                     const now = new Date();

--- a/src/Components/Chats.jsx
+++ b/src/Components/Chats.jsx
@@ -1,6 +1,6 @@
 import './Styles/Column2.css'
 import { useState, useEffect, useRef } from 'react';
-import { getAllChats, getChatPreivew, searchChats } from '../Services/ChatService';
+import { getChatPreivew, searchChats } from '../Services/ChatService';
 import DirectChatPreview from './DirectChatPreview';
 import { Skeleton } from "@/components/ui/skeleton";
 import { useIsMobile } from '../hooks/useIsMobile';

--- a/src/Components/Chats.jsx
+++ b/src/Components/Chats.jsx
@@ -179,30 +179,35 @@ export default function Chats({showDirectMessages, darkMode, setReceiverId, setS
                           </div>
                         ) : (
                             (searchKeyword === '' ? directChats : chats)
-                                .sort((a, b) => new Date(b.lastActiveTime) - new Date(a.lastActiveTime))
-                                .map((chat) => {
-                                    const now = new Date();
-                                    const date = new Date(chat.lastActiveTime);
+                                .sort((a, b) => {
+                                    const colomboOffset = 5.5 * 60 * 60000;
 
-                                    const colomboOffset = 5.5 * 60;
-                                    const colomboDate = new Date(date.getTime() + colomboOffset * 60000);
+                                    const dateA = new Date(new Date(a.lastActiveTime).getTime() + colomboOffset);
+                                    const dateB = new Date(new Date(b.lastActiveTime).getTime() + colomboOffset);
+
+                                    return dateB - dateA;
+                                })
+                                .map((chat) => {
+                                    const colomboOffset = 5.5 * 60 * 60000;
+                                    const now = new Date(new Date().getTime() + colomboOffset);
+                                    const date = new Date(new Date(chat.lastActiveTime).getTime() + colomboOffset);
 
                                     let formattedTime;
 
                                     if (
-                                        now.getFullYear() === colomboDate.getFullYear() &&
-                                        now.getMonth() === colomboDate.getMonth() &&
-                                        now.getDate() === colomboDate.getDate()
+                                        now.getFullYear() === date.getFullYear() &&
+                                        now.getMonth() === date.getMonth() &&
+                                        now.getDate() === date.getDate()
                                     ) {
-                                        formattedTime = `${colomboDate.getHours().toString().padStart(2, '0')}:${colomboDate.getMinutes().toString().padStart(2, '0')}`;
+                                        formattedTime = `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
                                     } else if (
-                                        now.getFullYear() === colomboDate.getFullYear() &&
-                                        now.getMonth() === colomboDate.getMonth() &&
-                                        now.getDate() - colomboDate.getDate() === 1
+                                        now.getFullYear() === date.getFullYear() &&
+                                        now.getMonth() === date.getMonth() &&
+                                        now.getDate() - date.getDate() === 1
                                     ) {
                                         formattedTime = 'Yesterday';
                                     } else {
-                                        formattedTime = `${colomboDate.getFullYear()}/${(colomboDate.getMonth() + 1).toString().padStart(2, '0')}/${colomboDate.getDate().toString().padStart(2, '0')}`;
+                                        formattedTime = `${date.getFullYear()}/${(date.getMonth() + 1).toString().padStart(2, '0')}/${date.getDate().toString().padStart(2, '0')}`;
                                     }
 
                                     return (

--- a/src/Components/Chats.jsx
+++ b/src/Components/Chats.jsx
@@ -183,22 +183,26 @@ export default function Chats({showDirectMessages, darkMode, setReceiverId, setS
                                 .map((chat) => {
                                     const now = new Date();
                                     const date = new Date(chat.lastActiveTime);
+
+                                    const colomboOffset = 5.5 * 60;
+                                    const colomboDate = new Date(date.getTime() + colomboOffset * 60000);
+
                                     let formattedTime;
 
                                     if (
-                                        now.getFullYear() === date.getFullYear() &&
-                                        now.getMonth() === date.getMonth() &&
-                                        now.getDate() === date.getDate()
+                                        now.getFullYear() === colomboDate.getFullYear() &&
+                                        now.getMonth() === colomboDate.getMonth() &&
+                                        now.getDate() === colomboDate.getDate()
                                     ) {
-                                        formattedTime = `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
+                                        formattedTime = `${colomboDate.getHours().toString().padStart(2, '0')}:${colomboDate.getMinutes().toString().padStart(2, '0')}`;
                                     } else if (
-                                        now.getFullYear() === date.getFullYear() &&
-                                        now.getMonth() === date.getMonth() &&
-                                        now.getDate() - date.getDate() === 1
+                                        now.getFullYear() === colomboDate.getFullYear() &&
+                                        now.getMonth() === colomboDate.getMonth() &&
+                                        now.getDate() - colomboDate.getDate() === 1
                                     ) {
                                         formattedTime = 'Yesterday';
                                     } else {
-                                        formattedTime = `${date.getFullYear()}/${(date.getMonth() + 1).toString().padStart(2, '0')}/${date.getDate().toString().padStart(2, '0')}`;
+                                        formattedTime = `${colomboDate.getFullYear()}/${(colomboDate.getMonth() + 1).toString().padStart(2, '0')}/${colomboDate.getDate().toString().padStart(2, '0')}`;
                                     }
 
                                     return (

--- a/src/Components/Chats.jsx
+++ b/src/Components/Chats.jsx
@@ -76,24 +76,6 @@ export default function Chats({showDirectMessages, darkMode, setReceiverId, setS
                 setLoading3(false);
             }
     };
-        
-    const fetchAllChats = async () => {
-        try {
-            const friendIds = await getAllChats(); 
-            const chatPreviews = await Promise.all(
-                friendIds.map(async (friendId) => {
-                    const chatPreview = await getChatPreivew(friendId);
-                    return chatPreview;
-                })
-            );
-            setChats(chatPreviews); 
-
-
-        }
-        finally {
-            setLoading(false);
-        }
-    };
     
     const showAllChats = () => {
         setShowAll(true);
@@ -106,15 +88,11 @@ export default function Chats({showDirectMessages, darkMode, setReceiverId, setS
         if (value.length > 0) {
             getSearchResults(value);
         }
-        else{
-            fetchAllChats();
-        }
     };
 
     const handleIconClick = async () => {
         if (searchKeyword !== '') {
           setSearchKeyword(''); 
-          fetchAllChats();
         }
     };
 

--- a/src/Components/DirectChat.jsx
+++ b/src/Components/DirectChat.jsx
@@ -129,9 +129,10 @@ export default function DirectChat({setMarketplaceMenu, showFriendInfoMenu, dark
     checkIsFriends();
     fetchFriendshipId();
     setIsFriend(true);
-    if (sessionStorage.getItem('userId') === '67a23983781fc24b8f9b71a1') {
+    /*if (sessionStorage.getItem('userId') === '67a23983781fc24b8f9b71a1') {
       setIsBeta(true);
-    }
+    }*/
+    setIsBeta(true);
 
     const chatContainer = chatRef.current;
     if (chatContainer) {

--- a/src/Components/DirectChat.jsx
+++ b/src/Components/DirectChat.jsx
@@ -254,7 +254,7 @@ export default function DirectChat({setMarketplaceMenu, showFriendInfoMenu, dark
   return (
     <div>
         <div className={`${darkMode ? 'bg-[#262729]' : 'bg-background' } min-h-screen flex flex-col`} >
-        <div className={`${darkMode ? 'border-gray-600' : 'border-border'} flex items-center px-4 py-3 border-b`} style={{ height: isMobile ? '10vh' : ''}}>
+        <div className={`${darkMode ? 'border-gray-600' : 'border-border'} flex items-center px-4 py-3 border-b`} style={{ height: isMobile ? '10vh' : '10vh'}}>
             {loading ? (
               <div>
                 <div className="flex items-center">
@@ -281,7 +281,7 @@ export default function DirectChat({setMarketplaceMenu, showFriendInfoMenu, dark
             ) }
             {isMobile && <p onClick={handleBackButton} className="text-primary font-medium text-lg cursor-pointer right-6 absolute">Back</p>}
         </div>
-        <div className="p-4" ref={chatRef} style={{height: isMobile ? '80vh' : '78vh', overflowY:'auto', scrollbarWidth:'none', backgroundImage: `url(${darkMode ? mainDark : mainLight})`, backgroundSize: 'cover'}}>
+        <div className="p-4" ref={chatRef} style={{height: isMobile ? '80vh' : '80vh', overflowY:'auto', scrollbarWidth:'none', backgroundImage: `url(${darkMode ? mainDark : mainLight})`, backgroundSize: 'cover'}}>
         {showScrollButton && !isMobile && <i onClick={scrollToBottom} className={`${darkMode ? 'bg-[#262729]' : 'bg-white'} cursor-pointer absolute bi bi-arrow-down-circle-fill text-4xl text-primary`} style={{left: '67%'}}></i>}
           {chatsLoading ? (
             <div className="text-center">
@@ -324,7 +324,7 @@ export default function DirectChat({setMarketplaceMenu, showFriendInfoMenu, dark
         </div>
         </div>}
         </div>
-        <div className={`${darkMode ? 'border-gray-600 bg-[#262729]' : 'border-border bg-card'} px-4 py-3  border-t`} style={{display:'flex', alignItems:'center',columnGap:'1rem', height: isMobile ? '10vh':''}}>
+        <div className={`${darkMode ? 'border-gray-600 bg-[#262729]' : 'border-border bg-card'} px-4 py-3  border-t`} style={{display:'flex', alignItems:'center',columnGap:'1rem', height: isMobile ? '10vh':'10vh'}}>
             {isFriend ? (<>
             {showEmojiPicker && 
               <div className="absolute" style={{left: '39%', bottom: '11%'}}>

--- a/src/Components/DirectChat.jsx
+++ b/src/Components/DirectChat.jsx
@@ -129,7 +129,7 @@ export default function DirectChat({setMarketplaceMenu, showFriendInfoMenu, dark
     checkIsFriends();
     fetchFriendshipId();
     setIsFriend(true);
-    if (sessionStorage.getItem('userId') === '679babbb1945b9025f11568c') {
+    if (sessionStorage.getItem('userId') === '67a23983781fc24b8f9b71a1') {
       setIsBeta(true);
     }
 

--- a/src/Components/DirectChat.jsx
+++ b/src/Components/DirectChat.jsx
@@ -133,7 +133,6 @@ export default function DirectChat({setMarketplaceMenu, showFriendInfoMenu, dark
       setIsBeta(true);
     }*/
     setIsBeta(true);
-
     const chatContainer = chatRef.current;
     if (chatContainer) {
       chatContainer.addEventListener("scroll", handleScroll);

--- a/src/Components/DirectChat.jsx
+++ b/src/Components/DirectChat.jsx
@@ -129,7 +129,6 @@ export default function DirectChat({setMarketplaceMenu, showFriendInfoMenu, dark
     checkIsFriends();
     fetchFriendshipId();
     setIsFriend(true);
-
     if (sessionStorage.getItem('userId') === '679babbb1945b9025f11568c') {
       setIsBeta(true);
     }
@@ -190,12 +189,9 @@ export default function DirectChat({setMarketplaceMenu, showFriendInfoMenu, dark
 
   useEffect(() => {
     fetchReceiverInfo();
+    fetchChatMessages();
     checkIsFriends();
     fetchFriendshipId();
-  }, [receiverId]);
-
-  useEffect(() => {
-    fetchChatMessages();
   }, [receiverId]);
 
   useEffect(() => {

--- a/src/Components/EditListing.jsx
+++ b/src/Components/EditListing.jsx
@@ -2,6 +2,7 @@ import './Styles/Column2.css'
 import { useState, useEffect } from 'react';
 import { getProductDetails } from  '../Services/MarketplaceService';
 import { useWebSocket } from '../Context/WebSocketContext';
+import { useIsMobile } from '../hooks/useIsMobile';
 
 export default function EditListing({showYourListningMenu, darkMode, editingProductId, autoScroll}) {
 
@@ -16,6 +17,7 @@ export default function EditListing({showYourListningMenu, darkMode, editingProd
     const [listedDate, setListedDate] = useState("");
     const [hideFromFriends, setHideFromFriends] = useState(false);
     const [errors, setErrors] = useState({});
+    const isMobile = useIsMobile();
 
     const validateFields = () => {
         const newErrors = {};
@@ -70,7 +72,7 @@ export default function EditListing({showYourListningMenu, darkMode, editingProd
     }
 
   return (
-    <div className="p-6 pt-1 bg-card text-card-foreground" style={{backgroundColor: darkMode ? '#262729' : ''}}>
+    <div className={`${isMobile ? 'py-6 px-1' : 'p-6'} pt-1 bg-card text-card-foreground`} style={{backgroundColor: darkMode ? '#262729' : ''}}>
         <h2 className={`${darkMode ? 'text-white':''} text-lg font-semibold mb-4`}>Edit listing</h2>
         <div className="bg-background px-4 py-0 rounded-lg w-full" style={{backgroundColor: darkMode ? '#262729' : ''}}>
                 <div className="mb-4">

--- a/src/Components/GroupChat.jsx
+++ b/src/Components/GroupChat.jsx
@@ -116,7 +116,6 @@ export default function GroupChat({ showGroupInfoMenu, darkMode, groupId, fetchU
   useEffect(() => {
     markMessagesAsRead();
     fetchGroupInfo();
-    fetchChatMessages();
   }, []);
 
   useEffect(() => {

--- a/src/Components/GroupChat.jsx
+++ b/src/Components/GroupChat.jsx
@@ -210,7 +210,7 @@ export default function GroupChat({ showGroupInfoMenu, darkMode, groupId, fetchU
   return (
     <div>
       <div className={`${darkMode ? 'bg-[#262729]' : 'bg-background'} min-h-screen flex flex-col`}>
-        <div className={`${darkMode ? 'border-gray-600' : 'border-border'} flex items-center px-4 py-3 border-b`} style={{ height: isMobile ? '10vh' : ''}}>
+        <div className={`${darkMode ? 'border-gray-600' : 'border-border'} flex items-center px-4 py-3 border-b`} style={{ height: isMobile ? '10vh' : '10vh'}}>
         {loading ? (
               <div>
                 <div className="flex items-center">
@@ -236,7 +236,7 @@ export default function GroupChat({ showGroupInfoMenu, darkMode, groupId, fetchU
             ) }
             {isMobile && <p onClick={handleBackButton} className="text-primary font-medium text-lg cursor-pointer right-6 absolute">Back</p>}
         </div>
-        <div className="p-4" ref={chatRef} style={{ height: isMobile ? '80vh' : '78vh', overflowY: 'auto', scrollbarWidth: 'none', backgroundImage: `url(${darkMode ? mainDark : mainLight})`, backgroundSize: 'cover' }}>
+        <div className="p-4" ref={chatRef} style={{ height: isMobile ? '80vh' : '80vh', overflowY: 'auto', scrollbarWidth: 'none', backgroundImage: `url(${darkMode ? mainDark : mainLight})`, backgroundSize: 'cover' }}>
           {showScrollButton && !isMobile && <i onClick={scrollToBottom} className={`${darkMode ? 'bg-[#262729]' : 'bg-white'} cursor-pointer absolute bi bi-arrow-down-circle-fill text-4xl text-primary`} style={{ left: '67%' }}></i>}
           {chatsLoading ? (
             <div className="text-center">
@@ -268,7 +268,7 @@ export default function GroupChat({ showGroupInfoMenu, darkMode, groupId, fetchU
           )}           
           {temporalMessage && <TemporalMessage message={temporalMessageContent}/> }         
         </div>
-        <div className={`${darkMode ? 'border-gray-600 bg-[#262729]' : 'border-border bg-card'} px-4 py-3 border-t`} style={{ display: 'flex', alignItems: 'center', columnGap: '1rem' , height: isMobile ? '10vh':''}}>
+        <div className={`${darkMode ? 'border-gray-600 bg-[#262729]' : 'border-border bg-card'} px-4 py-3 border-t`} style={{ display: 'flex', alignItems: 'center', columnGap: '1rem' , height: isMobile ? '10vh':'10vh'}}>
           {removedFromGroup ? (<div className={`${isMobile ? '': 'w-full mt-2'}`}>
             <p className={`${darkMode ? 'text-gray-300' : 'text-black' } text-sm text-center`}>You can't send messages to this group beacuse you're no longer a member.</p>
           </div>) : 

--- a/src/Components/GroupChatPreview.jsx
+++ b/src/Components/GroupChatPreview.jsx
@@ -7,7 +7,7 @@ export default function GroupChatPreview({darkMode, groupId, showGroupMessages, 
   
   const isMobile = useIsMobile();
   const [isUnread, setIsUnread] = useState(false);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   const handleGroupClick = () => {
     setGroupId(groupId);

--- a/src/Components/GroupChats.jsx
+++ b/src/Components/GroupChats.jsx
@@ -210,7 +210,7 @@ export default function GroupChats({showGroupMessages, darkMode, setGroupId, set
                     <div className="space-y-0">  
                     {loading2 ? (
                         <>
-                            {Array.from({ length: 6 }).map((_, index) => (
+                            {Array.from({ length: 4 }).map((_, index) => (
                                 <div key={index} className="flex items-center justify-between border-border py-2">
                                     <div className="flex items-center">
                                         <Skeleton className="rounded-full mr-2 w-10 h-10" />
@@ -349,7 +349,7 @@ export default function GroupChats({showGroupMessages, darkMode, setGroupId, set
                 {groupChatsMenu && <div>
                     {loadingGroupChats ? (
                             <div>
-                            {[...Array(6)].map((_, index) => (
+                            {[...Array(4)].map((_, index) => (
                               <div key={index} className="space-y-2">
                                 <div className={`flex items-center p-2 rounded`}>
                                   <Skeleton className="h-12 w-12 rounded-full mr-2" />

--- a/src/Components/GroupChats.jsx
+++ b/src/Components/GroupChats.jsx
@@ -364,30 +364,35 @@ export default function GroupChats({showGroupMessages, darkMode, setGroupId, set
                           </div>
                         ) : (
                             groupChats
-                                .sort((a, b) => new Date(b.lastUpdate) - new Date(a.lastUpdate))
+                                .sort((a, b) => {
+                                    const colomboOffset = 5.5 * 60 * 60000;
+
+                                    const dateA = new Date(new Date(a.lastUpdate).getTime() + colomboOffset);
+                                    const dateB = new Date(new Date(b.lastUpdate).getTime() + colomboOffset);
+
+                                    return dateB - dateA;
+                                })
                                 .map((group) => {
-                                    const now = new Date();
-                                    const date = new Date(group.lastUpdate);
-                                
-                                    const colomboOffset = 5.5 * 60; 
-                                    const colomboDate = new Date(date.getTime() + colomboOffset * 60000); 
+                                    const colomboOffset = 5.5 * 60 * 60000;
+                                    const now = new Date(new Date().getTime() + colomboOffset);
+                                    const date = new Date(new Date(group.lastUpdate).getTime() + colomboOffset);
 
                                     let formattedTime;
 
                                     if (
-                                        now.getFullYear() === colomboDate.getFullYear() &&
-                                        now.getMonth() === colomboDate.getMonth() &&
-                                        now.getDate() === colomboDate.getDate()
+                                        now.getFullYear() === date.getFullYear() &&
+                                        now.getMonth() === date.getMonth() &&
+                                        now.getDate() === date.getDate()
                                     ) {
-                                        formattedTime = `${colomboDate.getHours().toString().padStart(2, '0')}:${colomboDate.getMinutes().toString().padStart(2, '0')}`;
+                                        formattedTime = `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
                                     } else if (
-                                        now.getFullYear() === colomboDate.getFullYear() &&
-                                        now.getMonth() === colomboDate.getMonth() &&
-                                        now.getDate() - colomboDate.getDate() === 1
+                                        now.getFullYear() === date.getFullYear() &&
+                                        now.getMonth() === date.getMonth() &&
+                                        now.getDate() - date.getDate() === 1
                                     ) {
                                         formattedTime = 'Yesterday';
                                     } else {
-                                        formattedTime = `${colomboDate.getFullYear()}/${(colomboDate.getMonth() + 1).toString().padStart(2, '0')}/${colomboDate.getDate().toString().padStart(2, '0')}`;
+                                        formattedTime = `${date.getFullYear()}/${(date.getMonth() + 1).toString().padStart(2, '0')}/${date.getDate().toString().padStart(2, '0')}`;
                                     }
 
                                     return (

--- a/src/Components/GroupChats.jsx
+++ b/src/Components/GroupChats.jsx
@@ -368,22 +368,26 @@ export default function GroupChats({showGroupMessages, darkMode, setGroupId, set
                                 .map((group) => {
                                     const now = new Date();
                                     const date = new Date(group.lastUpdate);
+                                
+                                    const colomboOffset = 5.5 * 60; 
+                                    const colomboDate = new Date(date.getTime() + colomboOffset * 60000); 
+
                                     let formattedTime;
 
                                     if (
-                                        now.getFullYear() === date.getFullYear() &&
-                                        now.getMonth() === date.getMonth() &&
-                                        now.getDate() === date.getDate()
+                                        now.getFullYear() === colomboDate.getFullYear() &&
+                                        now.getMonth() === colomboDate.getMonth() &&
+                                        now.getDate() === colomboDate.getDate()
                                     ) {
-                                        formattedTime = `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
+                                        formattedTime = `${colomboDate.getHours().toString().padStart(2, '0')}:${colomboDate.getMinutes().toString().padStart(2, '0')}`;
                                     } else if (
-                                        now.getFullYear() === date.getFullYear() &&
-                                        now.getMonth() === date.getMonth() &&
-                                        now.getDate() - date.getDate() === 1
+                                        now.getFullYear() === colomboDate.getFullYear() &&
+                                        now.getMonth() === colomboDate.getMonth() &&
+                                        now.getDate() - colomboDate.getDate() === 1
                                     ) {
                                         formattedTime = 'Yesterday';
                                     } else {
-                                        formattedTime = `${date.getFullYear()}/${(date.getMonth() + 1).toString().padStart(2, '0')}/${date.getDate().toString().padStart(2, '0')}`;
+                                        formattedTime = `${colomboDate.getFullYear()}/${(colomboDate.getMonth() + 1).toString().padStart(2, '0')}/${colomboDate.getDate().toString().padStart(2, '0')}`;
                                     }
 
                                     return (

--- a/src/Components/GroupReceiveMessage.jsx
+++ b/src/Components/GroupReceiveMessage.jsx
@@ -7,7 +7,14 @@ export default function GroupReceiveMessage({message, time, senderName}) {
         <div className="bg-[#1c1c1c] text-white p-2 rounded-lg max-w-xs break-words">
             <span className="text-primary" style={{fontSize:'85%'}}>{senderName}</span>
             <p style={{fontSize:'95%'}}>{message}</p>
-            <span className="text-xs text-muted-foreground">{time}</span>
+            <span className="text-xs text-muted-foreground">
+              {(() => {
+                  const [hours, minutes] = time.split(':').map(num => parseInt(num));
+                  const colomboHours = (hours + 5 + 30 / 60) % 24;
+                  const colomboMinutes = minutes;
+                  return `${Math.floor(colomboHours).toString().padStart(2, '0')}:${colomboMinutes.toString().padStart(2, '0')}`;
+                })()}
+            </span>
         </div>
         </div>
     </div>

--- a/src/Components/GroupReceiveMessage.jsx
+++ b/src/Components/GroupReceiveMessage.jsx
@@ -8,11 +8,10 @@ export default function GroupReceiveMessage({message, time, senderName}) {
             <span className="text-primary" style={{fontSize:'85%'}}>{senderName}</span>
             <p style={{fontSize:'95%'}}>{message}</p>
             <span className="text-xs text-muted-foreground">
-              {(() => {
-                  const [hours, minutes] = time.split(':').map(num => parseInt(num));
-                  const colomboHours = (hours + 5 + 30 / 60) % 24;
-                  const colomboMinutes = minutes;
-                  return `${Math.floor(colomboHours).toString().padStart(2, '0')}:${colomboMinutes.toString().padStart(2, '0')}`;
+                {(() => {
+                  const [hours, minutes] = time.split(':').map(Number);
+                  const colomboDate = new Date(0, 0, 0, hours + 5, minutes + 30);
+                  return colomboDate.toTimeString().slice(0, 5);
                 })()}
             </span>
         </div>

--- a/src/Components/GroupSendMessage.jsx
+++ b/src/Components/GroupSendMessage.jsx
@@ -7,7 +7,14 @@ export default function GroupSendMessage({message, time}) {
         <div className="bg-primary text-white p-2 rounded-lg max-w-xs break-words">
             <p style={{fontSize:'95%'}}>{message}</p>
             <div className='pr-1' style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
-              <span className="text-xs text-gray-600 pr-5">{time}</span>
+              <span className="text-xs text-gray-600 pr-5">
+                {(() => {
+                  const [hours, minutes] = time.split(':').map(num => parseInt(num));
+                  const colomboHours = (hours + 5 + 30 / 60) % 24;
+                  const colomboMinutes = minutes;
+                  return `${Math.floor(colomboHours).toString().padStart(2, '0')}:${colomboMinutes.toString().padStart(2, '0')}`;
+                })()}
+              </span>
               <i className="bi bi-check2-all"></i>
             </div>
         </div>

--- a/src/Components/GroupSendMessage.jsx
+++ b/src/Components/GroupSendMessage.jsx
@@ -9,10 +9,9 @@ export default function GroupSendMessage({message, time}) {
             <div className='pr-1' style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
               <span className="text-xs text-gray-600 pr-5">
                 {(() => {
-                  const [hours, minutes] = time.split(':').map(num => parseInt(num));
-                  const colomboHours = (hours + 5 + 30 / 60) % 24;
-                  const colomboMinutes = minutes;
-                  return `${Math.floor(colomboHours).toString().padStart(2, '0')}:${colomboMinutes.toString().padStart(2, '0')}`;
+                  const [hours, minutes] = time.split(':').map(Number);
+                  const colomboDate = new Date(0, 0, 0, hours + 5, minutes + 30);
+                  return colomboDate.toTimeString().slice(0, 5);
                 })()}
               </span>
               <i className="bi bi-check2-all"></i>

--- a/src/Components/Marketplace.jsx
+++ b/src/Components/Marketplace.jsx
@@ -3,7 +3,7 @@ import './Styles/Column2.css'
 import ProductInfo from './ProductInfo';
 import YourListings from './YourListings';
 import EditListing from './EditListing';
-import { getMarketplaceItems, getActiveListingCount, getMyListings, isUserSeller, getTotalClicks, searchProducts} from  '../Services/MarketplaceService';
+import { getActiveListingCount, getMyListings, getTotalClicks, searchProducts} from  '../Services/MarketplaceService';
 import PreviewProduct from './PreviewProduct';
 import { Skeleton } from "@/components/ui/skeleton";
 import { useWebSocket } from '../Context/WebSocketContext';
@@ -11,19 +11,18 @@ import { uploadMultipleFiles } from '../Services/s3Service';
 import { useIsMobile } from '../hooks/useIsMobile';
 import errDark from '@/assets/Icons/listingErdark.png';
 import errLight from '@/assets/Icons/listingEr.png';
+import { useGlobalStore } from '../States/UseStore';
 
 export default function Marketplace({darkMode, showDirectMessages, setReceiverId, setShowMobileRight}) {
 
     const isMobile = useIsMobile();
-    const { messages, addListing } = useWebSocket();
-    const [processedMessages, setProcessedMessages] = useState([]);
+    const { addListing } = useWebSocket();
 
-    const [productList, setProductList] = useState([]);
+    const { productList, loadingProducts } = useGlobalStore();
     const [resultsList, setResultsList] = useState([]);
     const [myListings, setMyListings] = useState([]);
     const [editingProductId, setEditingProductId] = useState();
     const [expandingProductId, setExpandingProductId] = useState();
-    const [loading, setLoading] = useState(true); 
     const [loadingResults, setLoadingResults] = useState(true);
  
     const [forYouMenu, setForYouMenu] = useState(true);
@@ -156,15 +155,6 @@ export default function Marketplace({darkMode, showDirectMessages, setReceiverId
         }
     }
     
-    const fetchMarketplaceItems = async () => {
-        try{
-            const response = await getMarketplaceItems();
-            setProductList(response);
-        } finally {
-            setLoading(false);
-        }
-    };
-
     const fetchSearchResults = async () => {
         const response = await searchProducts(searchKeyword);
         setResultsList(response);
@@ -192,9 +182,6 @@ export default function Marketplace({darkMode, showDirectMessages, setReceiverId
         fetchMyListings();
     }, [productList]);
 
-    useEffect(() => {
-        fetchMarketplaceItems();
-    }, []);
 
     function handleFileChange(event) {
         const files = Array.from(event.target.files); 
@@ -255,46 +242,6 @@ export default function Marketplace({darkMode, showDirectMessages, setReceiverId
         setYourListningMenu(false);
         setShowResults(false);
     }
-
-    useEffect(() => {
-        const handleMessages = async () => {
-            if (messages.length === 0) {
-                return;
-            }
-            const newMessages = messages.filter(message => !processedMessages.includes(message.id));
-            if (newMessages.length === 0) {
-                return; 
-            }
-            for (const lastMessage of newMessages) {
-                switch (lastMessage.action) {
-                    case 'marketplaceService': {
-                        fetchMarketplaceItems();
-                        break; 
-                    }
-                    case 'profileService': {
-                        const response = await isUserSeller(lastMessage.body);
-                        if(response){
-                            fetchMarketplaceItems();
-                        }
-                        break;  
-                    }
-                    case 'accountDelete':{
-                        if (lastMessage.typeOfAction === 'marketplace') {
-                            fetchMarketplaceItems();
-                        }
-                        break;
-                    }
-                    default:
-                        break;
-                }
-            }
-            setProcessedMessages(prevProcessedMessages => [
-                ...prevProcessedMessages,
-                ...newMessages.map(message => message.id),
-            ]);
-        };
-        handleMessages();
-    }, [messages, processedMessages]); 
 
   return (
     <div>
@@ -367,7 +314,7 @@ export default function Marketplace({darkMode, showDirectMessages, setReceiverId
             {forYouMenu && 
                 <div className='product-list' style={{height: isMobile ? '55vh' : ''}}>
                     <div className="grid grid-cols-2 gap-x-4 gap-y-5 p-0 w-full"> 
-                    {loading ? (<>
+                    {loadingProducts ? (<>
                         {Array.from({ length: 6 }).map((_, index) => (
                             <div
                             key={index}

--- a/src/Components/Marketplace.jsx
+++ b/src/Components/Marketplace.jsx
@@ -156,8 +156,13 @@ export default function Marketplace({darkMode, showDirectMessages, setReceiverId
     }
     
     const fetchSearchResults = async () => {
-        const response = await searchProducts(searchKeyword);
-        setResultsList(response);
+        try{
+            const response = await searchProducts(searchKeyword);
+            setResultsList(response);
+            console.log(response);
+        } finally{
+            setLoadingResults(false);
+        }
     }
 
     const fetchActiveListingCount = async () => {

--- a/src/Components/Marketplace.jsx
+++ b/src/Components/Marketplace.jsx
@@ -374,7 +374,7 @@ export default function Marketplace({darkMode, showDirectMessages, setReceiverId
                     </div>
                 </div>
                 <h2 className={`${darkMode ? 'text-white':''} text-lg font-semibold mb-2 mt-5`}>New listing</h2>
-                <div className="bg-background p-6 rounded-lg w-full" style={{backgroundColor: darkMode ? '#262729' : ''}}>
+                <div className={`bg-background ${isMobile ? 'py-6 px-1' : 'p-6'} rounded-lg w-full`} style={{backgroundColor: darkMode ? '#262729' : ''}}>
                 <div className="flex flex-col items-center mb-4">
                 <div style={{display:'flex',flexDirection:'column', justifyContent:'center', alignItems:'center'}}>
                     <div className="grid grid-cols-3 gap-1 mb-4">

--- a/src/Components/PreviewAcceptedRequests.jsx
+++ b/src/Components/PreviewAcceptedRequests.jsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { useWebSocket } from "../Context/WebSocketContext";
 
-export default function PreviewAcceptedRequests({darkMode, friendshipId, profileName, profilePicture, profileAbout, fetchFriendships, showDirectMessages, setReceiverId, friendId, setShowMobileRight}) {
+export default function PreviewAcceptedRequests({darkMode, friendshipId, profileName, profilePicture, profileAbout, showDirectMessages, setReceiverId, friendId, setShowMobileRight}) {
   
     const isMobile = useIsMobile();
     const { unFriend } = useWebSocket();
@@ -19,7 +19,6 @@ export default function PreviewAcceptedRequests({darkMode, friendshipId, profile
         let linkedProfiles = JSON.parse(sessionStorage.getItem('linkedProfiles'));
         linkedProfiles = linkedProfiles.filter(profile => profile !== friendshipId);
         sessionStorage.setItem('linkedProfiles', JSON.stringify(linkedProfiles));
-        fetchFriendships();
         await unFriend(friendshipId);
         setIsUnfriended(true);
         setUnfriendPopup(false);

--- a/src/Components/Profile.jsx
+++ b/src/Components/Profile.jsx
@@ -1,11 +1,11 @@
-import { useRef, useState, useEffect} from 'react';
+import { useRef, useState } from 'react';
 import './Styles/Column2.css'
 import AvatarEditor from 'react-avatar-editor'
 import Slider from '@mui/material/Slider';
-import { fetchUserMetaData } from '../Services/ProfileService';
 import { uploadFile } from '../Services/s3Service';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { useWebSocket } from '../Context/WebSocketContext';
+import { useGlobalStore } from '../States/UseStore';
 
 export default function Profile({darkMode, setUserPicture}) {
     
@@ -20,21 +20,8 @@ export default function Profile({darkMode, setUserPicture}) {
     const [cropedImage, setCropedImage] = useState(null);
     const fileInputRef = useRef(null);
     const avatarEditorRef = useRef(null);  
-    const [name, setName] = useState('');
-    const [about, setAbout] = useState('');
-    const [email, setEmail] = useState('');
-    const [profilePicture, setProfilePicture] = useState('');
+    const { setName, setEmail, setAbout, setProfilePicture, name, email, about, profilePicture } = useGlobalStore();
 
-    useEffect(() => {
-        const fetchUser = async () => {
-            const response = await fetchUserMetaData();
-            setName(response.userName);
-            setAbout(response.about);
-            setEmail(response.email);
-            setProfilePicture(response.profilePicture);
-        };
-        fetchUser();
-    }, []);    
 
     const handleImageUpload = async () => {
         const blob = await fetch(selectedImage).then(res => res.blob());

--- a/src/Components/ReceiveMessage.jsx
+++ b/src/Components/ReceiveMessage.jsx
@@ -6,7 +6,14 @@ export default function ReceiveMessage({message, time}) {
         <div className="flex items-start mb-2">
         <div className="bg-[#1c1c1c] text-white p-2 rounded-lg max-w-xs break-words">
             <p style={{fontSize:'95%'}}>{message}</p>
-            <span className="text-xs text-muted-foreground">{time}</span>
+            <span className="text-xs text-muted-foreground">
+              {(() => {
+                const [hours, minutes] = time.split(':').map(num => parseInt(num));
+                const colomboHours = (hours + 5 + 30 / 60) % 24;
+                const colomboMinutes = minutes;
+                return `${Math.floor(colomboHours).toString().padStart(2, '0')}:${colomboMinutes.toString().padStart(2, '0')}`;
+              })()}
+            </span>
         </div>
         </div>
     </div>

--- a/src/Components/ReceiveMessage.jsx
+++ b/src/Components/ReceiveMessage.jsx
@@ -7,12 +7,11 @@ export default function ReceiveMessage({message, time}) {
         <div className="bg-[#1c1c1c] text-white p-2 rounded-lg max-w-xs break-words">
             <p style={{fontSize:'95%'}}>{message}</p>
             <span className="text-xs text-muted-foreground">
-              {(() => {
-                const [hours, minutes] = time.split(':').map(num => parseInt(num));
-                const colomboHours = (hours + 5 + 30 / 60) % 24;
-                const colomboMinutes = minutes;
-                return `${Math.floor(colomboHours).toString().padStart(2, '0')}:${colomboMinutes.toString().padStart(2, '0')}`;
-              })()}
+                {(() => {
+                  const [hours, minutes] = time.split(':').map(Number);
+                  const colomboDate = new Date(0, 0, 0, hours + 5, minutes + 30);
+                  return colomboDate.toTimeString().slice(0, 5);
+                })()}
             </span>
         </div>
         </div>

--- a/src/Components/SendMessage.jsx
+++ b/src/Components/SendMessage.jsx
@@ -9,11 +9,10 @@ export default function SendMessage({message, time}) {
             <div className='pr-1' style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
               <span className="text-xs text-gray-600 pr-5">
                 {(() => {
-                  const [hours, minutes] = time.split(':').map(num => parseInt(num));
-                  const colomboHours = (hours + 5 + 30 / 60) % 24;
-                  const colomboMinutes = minutes;
-                  return `${Math.floor(colomboHours).toString().padStart(2, '0')}:${colomboMinutes.toString().padStart(2, '0')}`;
-                })()}                
+                  const [hours, minutes] = time.split(':').map(Number);
+                  const colomboDate = new Date(0, 0, 0, hours + 5, minutes + 30);
+                  return colomboDate.toTimeString().slice(0, 5);
+                })()}               
               </span>
               <i className="bi bi-check2-all"></i>
             </div>

--- a/src/Components/SendMessage.jsx
+++ b/src/Components/SendMessage.jsx
@@ -7,7 +7,14 @@ export default function SendMessage({message, time}) {
         <div className="bg-primary text-white p-2 rounded-lg max-w-xs break-words">
             <p style={{fontSize:'95%'}}>{message}</p>
             <div className='pr-1' style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
-              <span className="text-xs text-gray-600 pr-5">{time}</span>
+              <span className="text-xs text-gray-600 pr-5">
+                {(() => {
+                  const [hours, minutes] = time.split(':').map(num => parseInt(num));
+                  const colomboHours = (hours + 5 + 30 / 60) % 24;
+                  const colomboMinutes = minutes;
+                  return `${Math.floor(colomboHours).toString().padStart(2, '0')}:${colomboMinutes.toString().padStart(2, '0')}`;
+                })()}                
+              </span>
               <i className="bi bi-check2-all"></i>
             </div>
         </div>

--- a/src/Pages/Dashboard.jsx
+++ b/src/Pages/Dashboard.jsx
@@ -202,6 +202,9 @@ export default function Dashboard() {
                     }
                     fetchMarketplaceItems();
                 }
+                else if (lastMessage.action === 'groupService'){
+                    fetchAllGroups();
+                }
                 else if (lastMessage.action === 'messageService'){
                     if(lastMessage.type === 'direct'){
                         fetchUnreadMessages();

--- a/src/Pages/Dashboard.jsx
+++ b/src/Pages/Dashboard.jsx
@@ -575,12 +575,12 @@ export default function Dashboard() {
             {!isMobile && <>
             <div className="flex-1 p-0 messages-column" style={{height:'100vh'}}>
                 {welcomeVideo &&
-                <div className="w-full flex flexflex-column items-center justify-center" style={{height:'100vh', backgroundImage: `url(${darkMode ? mainDark : mainLight})`, backgroundSize: 'cover'}}>
+                <div className="w-full pl-2 flex flex-column items-center justify-center" style={{height:'100vh', backgroundImage: `url(${darkMode ? mainDark : mainLight})`, backgroundSize: 'cover'}}>
                     <img src={mainLogo} className='absolute mt-[-35%] right-[4%]'  style={{width:'10%'}}/>
-                    <MorphingText  texts={texts} className="text-primary dark:text-white right-[7%] absolute mt-[-8%] text-left"/>
-                    <div className='text-primary mt-[60%]'>
+                    <MorphingText  texts={texts} className="text-primary dark:text-white text-left mt-[-10%]"/>
+                    <div className='text-primary absolute bottom-[5%] ml-[-2%]'>
                         <i className="bi bi-lock-fill"></i>&nbsp;<p className='inline'>Your personal messages are end-to-end encrypted</p>
-                    </div>  
+                    </div>
                 </div>
                 }
                 {directMessages && <DirectChat fetchUnreadMessages={fetchUnreadMessages} receiverId={receiverId} darkMode={darkMode} showFriendInfoMenu={showFriendInfoMenu}/>} 

--- a/src/Pages/Dashboard.jsx
+++ b/src/Pages/Dashboard.jsx
@@ -31,7 +31,7 @@ export default function Dashboard() {
 
     const isMobile = useIsMobile();
     const { messages } = useWebSocket();
-    const { directChats, setDirectChats, setLoadingDirectChats, groupChats, setGroupChats, setLoadingGroupChats, setPendingProfiles, setAcceptedProfiles, setLoadingFriendships } = useGlobalStore();
+    const { setName, setEmail, setAbout, setProfilePicture, directChats, setDirectChats, setLoadingDirectChats, groupChats, setGroupChats, setLoadingGroupChats, setPendingProfiles, setAcceptedProfiles, setLoadingFriendships } = useGlobalStore();
     const [processedMessages, setProcessedMessages] = useState([]);
     
     const audioRef = useRef(null);
@@ -111,6 +111,10 @@ export default function Dashboard() {
             const response = await fetchUserMetaData();
             if (userPicture === 'url')
                 setUserPicture(response.profilePicture);
+            setName(response.userName);
+            setAbout(response.about);
+            setEmail(response.email);
+            setProfilePicture(response.profilePicture);
         };
         fetchDarkModePreference();
         fetchUser();
@@ -120,6 +124,7 @@ export default function Dashboard() {
         fetchAllChats();
         fetchAllGroups();
         fetchFriendships();
+        fetchUser();
     }, []);
 
     useEffect(() => {
@@ -270,7 +275,7 @@ export default function Dashboard() {
             ]);
         };
         handleMessages();
-    }, [messages, processedMessages]); 
+    }, [messages, processedMessages]);
     
     const fetchAllChats = async () => {
         try {

--- a/src/States/UseStore.jsx
+++ b/src/States/UseStore.jsx
@@ -7,6 +7,9 @@ export function GlobalProvider({ children }) {
   const [loadingDirectChats, setLoadingDirectChats] = useState(true);
   const [groupChats, setGroupChats] = useState([]);
   const [loadingGroupChats, setLoadingGroupChats] = useState(true);
+  const [pendingProfiles, setPendingProfiles] = useState([]);
+  const [acceptedProfiles, setAcceptedProfiles] = useState([]);
+  const [loadingFriendships, setLoadingFriendships] = useState(true);
 
   const value = {
     directChats,
@@ -17,6 +20,12 @@ export function GlobalProvider({ children }) {
     setGroupChats,
     loadingGroupChats,
     setLoadingGroupChats,
+    pendingProfiles,
+    setPendingProfiles,
+    acceptedProfiles,
+    setAcceptedProfiles,
+    loadingFriendships,
+    setLoadingFriendships,
   };
 
   return (

--- a/src/States/UseStore.jsx
+++ b/src/States/UseStore.jsx
@@ -10,6 +10,10 @@ export function GlobalProvider({ children }) {
   const [pendingProfiles, setPendingProfiles] = useState([]);
   const [acceptedProfiles, setAcceptedProfiles] = useState([]);
   const [loadingFriendships, setLoadingFriendships] = useState(true);
+  const [name, setName] = useState('');
+  const [about, setAbout] = useState('');
+  const [email, setEmail] = useState('');
+  const [profilePicture, setProfilePicture] = useState('');
 
   const value = {
     directChats,
@@ -26,6 +30,14 @@ export function GlobalProvider({ children }) {
     setAcceptedProfiles,
     loadingFriendships,
     setLoadingFriendships,
+    name,
+    email,
+    about,
+    profilePicture,
+    setName,
+    setEmail,
+    setAbout,
+    setProfilePicture
   };
 
   return (

--- a/src/States/UseStore.jsx
+++ b/src/States/UseStore.jsx
@@ -14,6 +14,8 @@ export function GlobalProvider({ children }) {
   const [about, setAbout] = useState('');
   const [email, setEmail] = useState('');
   const [profilePicture, setProfilePicture] = useState('');
+  const [productList, setProductList] = useState([]);
+  const [loadingProducts, setLoadingProducts] = useState(true);
 
   const value = {
     directChats,
@@ -37,7 +39,11 @@ export function GlobalProvider({ children }) {
     setName,
     setEmail,
     setAbout,
-    setProfilePicture
+    setProfilePicture,
+    productList,
+    setProductList,
+    loadingProducts,
+    setLoadingProducts
   };
 
   return (

--- a/src/States/UseStore.jsx
+++ b/src/States/UseStore.jsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useState } from 'react';
+
+const GlobalContext = createContext();
+
+export function GlobalProvider({ children }) {
+  const [directChats, setDirectChats] = useState([]);
+  const [loadingDirectChats, setLoadingDirectChats] = useState(true);
+  const [groupChats, setGroupChats] = useState([]);
+  const [loadingGroupChats, setLoadingGroupChats] = useState(true);
+
+  const value = {
+    directChats,
+    setDirectChats,
+    loadingDirectChats,
+    setLoadingDirectChats,
+    groupChats,
+    setGroupChats,
+    loadingGroupChats,
+    setLoadingGroupChats,
+  };
+
+  return (
+    <GlobalContext.Provider value={value}>
+      {children}
+    </GlobalContext.Provider>
+  );
+}
+
+
+export function useGlobalStore() {
+  const context = useContext(GlobalContext);
+  if (!context) {
+    throw new Error('useGlobalStore must be used within a GlobalProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
This pull request introduces a new global state management system using `zustand` and refactors several components to utilize this new state management. The most significant changes include the addition of `zustand` to the project dependencies, the integration of `GlobalProvider` in the main application component, and the refactoring of chat-related components to use the global state.

### Dependency Updates:
* Added `zustand` to the project dependencies in `package.json`.

### Global State Management Integration:
* Integrated `GlobalProvider` in `src/App.jsx` to wrap the main application component. [[1]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R6) [[2]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R19-R27)

### Refactoring Components to Use Global State:
* Refactored `src/Components/Chats.jsx` to use global state from `zustand` for managing chat data, removing local state and redundant fetch functions. [[1]](diffhunk://#diff-0a140a78f64c1806e773ec88afa32b2ca36b94425993796b4aef241a6fa1246fL3-R35) [[2]](diffhunk://#diff-0a140a78f64c1806e773ec88afa32b2ca36b94425993796b4aef241a6fa1246fL74-L162) [[3]](diffhunk://#diff-0a140a78f64c1806e773ec88afa32b2ca36b94425993796b4aef241a6fa1246fL174-L182) [[4]](diffhunk://#diff-0a140a78f64c1806e773ec88afa32b2ca36b94425993796b4aef241a6fa1246fL252-R165) [[5]](diffhunk://#diff-0a140a78f64c1806e773ec88afa32b2ca36b94425993796b4aef241a6fa1246fL268-R194)
* Modified `src/Components/Friends.jsx` to use global state for managing friendship data, removing local state and redundant fetch functions. [[1]](diffhunk://#diff-6eb8fd7707ee2c3116454011c17fa4a6a54168b0c691928dfb2a14f3d247a9e5L3-L30) [[2]](diffhunk://#diff-6eb8fd7707ee2c3116454011c17fa4a6a54168b0c691928dfb2a14f3d247a9e5L41-L86)

### Minor Fixes and Cleanup:
* Removed redundant code and fixed minor issues in `src/Components/DirectChat.jsx` and `src/Components/EditListing.jsx`. [[1]](diffhunk://#diff-e1fd0b905ef31f59e05b26a7d28afd82e3b28f155f63ba2ee64641520f53d558L132-L136) [[2]](diffhunk://#diff-e1fd0b905ef31f59e05b26a7d28afd82e3b28f155f63ba2ee64641520f53d558R192-L200) [[3]](diffhunk://#diff-e1fd0b905ef31f59e05b26a7d28afd82e3b28f155f63ba2ee64641520f53d558L261-R257) [[4]](diffhunk://#diff-e1fd0b905ef31f59e05b26a7d28afd82e3b28f155f63ba2ee64641520f53d558L288-R284) [[5]](diffhunk://#diff-e1fd0b905ef31f59e05b26a7d28afd82e3b28f155f63ba2ee64641520f53d558L331-R327) [[6]](diffhunk://#diff-59dfb1884c020fd6459058713d29d9ac52eb10c4296b9cf98cbf03df68fc9741R5) [[7]](diffhunk://#diff-59dfb1884c020fd6459058713d29d9ac52eb10c4296b9cf98cbf03df68fc9741R20) [[8]](diffhunk://#diff-59dfb1884c020fd6459058713d29d9ac52eb10c4296b9cf98cbf03df68fc9741L73-R75)